### PR TITLE
bump mongoose-q version for node v6 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "hooks": "~0.3.2",
     "minimatch": "^1.0.0",
     "moment": "~2.6.0",
-    "mongoose-q": "0.0.13",
+    "mongoose-q": "0.1.0",
     "q": "*",
     "underscore": "~1.5.2"
   },


### PR DESCRIPTION
Bumped mongoose-q version to 0.1.0 which uses mongoose 4.x and mongodb 2.x