### PR TITLE
getting rid of mongoose-q

### DIFF
--- a/lib/endpoint.coffee
+++ b/lib/endpoint.coffee
@@ -1,4 +1,4 @@
-mongoose = require('mongoose-q')()
+mongoose = require('mongoose')
 _ = require('underscore')
 Q = require('q')
 log = require('./log')

--- a/lib/endpoint.coffee
+++ b/lib/endpoint.coffee
@@ -1,6 +1,7 @@
-mongoose = require('mongoose')
-_ = require('underscore')
 Q = require('q')
+mongoose = require('mongoose')
+mongoose.Promise = Q.Promise;
+_ = require('underscore')
 log = require('./log')
 request = require('./request')
 minimatch = require('minimatch')

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -86,11 +86,11 @@ module.exports = class Request
 		data = req.query
 
 		result = 
-			perPage:data.perPage
+			perPage:parseInt(data.perPage, 10)
 			page:data.page
 			sortField:data.sortField
 			sortDirection:data.sortDirection
-		result.page = parseInt(data.page)
+		result.page = parseInt(data.page, 10)
 		if !result.page? or isNaN(result.page) or result.page < 1
 			result.page = 1
 		if !result.perPage?

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -129,7 +129,7 @@ module.exports = class Request
 			filter._id = id
 			query = @$modelClass.findOne(filter)
 			@$populateQuery(query)
-			return query.execQ()
+			return query.exec()
 		.then (model) =>
 			if !model
 				log 'ERROR:'.red, 'Object not found'
@@ -203,7 +203,7 @@ module.exports = class Request
 		.then (query) =>
 			if @$endpoint.options.limitFields?
 				query.select(@$endpoint.options.limitFields.join(' '))
-			return query.execQ()
+			return query.exec()
 		.then (response) =>
 			return @$runHook('post_retrieve', 'list', req, response)
 		.then (response) =>
@@ -342,7 +342,7 @@ module.exports = class Request
 			query = @$modelClass.findOne(filter)
 
 			@$populateQuery(query)
-			return query.execQ()
+			return query.exec()
 		.then (model) =>
 			if !model
 				log 'ERROR:'.red, 'No model found (404)'
@@ -413,7 +413,7 @@ module.exports = class Request
 			query = @$modelClass.findOne(filter)
 
 			@$populateQuery(query)
-			return query.execQ()
+			return query.exec()
 		.then (model) =>
 			if !model
 				log 'ERROR:'.red, 'No model found (404)'

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -86,7 +86,7 @@ module.exports = class Request
 		data = req.query
 
 		result = 
-			perPage:parseInt(data.perPage, 10)
+			perPage: data.perPage && parseInt(data.perPage, 10)
 			page:data.page
 			sortField:data.sortField
 			sortDirection:data.sortDirection

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -175,7 +175,7 @@ module.exports = class Request
 					# sorting =
 					# 	config.sortField: config.sortDirection
 					query.sort(config.sortField).skip((config.page - 1) * config.perPage).limit(config.perPage)
-					deferred.resolve(query)
+					deferred.resolve({query})
 				else
 					
 					@$modelClass.count(filter)
@@ -188,10 +188,10 @@ module.exports = class Request
 						if config.sortDirection is -1
 							config.sortField = '-' + config.sortField
 						query.sort(config.sortField).skip((config.page - 1) * config.perPage).limit(config.perPage)
-						deferred.resolve(query)
+						deferred.resolve({query})
 					.fail(deferred.reject).done()
 			else
-				deferred.resolve(query)
+				deferred.resolve({query})
 
 			return deferred.promise
 
@@ -200,7 +200,7 @@ module.exports = class Request
 			@$populateQuery(query)
 			# Handle pagination
 			return applyPagination(query, filter)
-		.then (query) =>
+		.then ({query}) =>
 			if @$endpoint.options.limitFields?
 				query.select(@$endpoint.options.limitFields.join(' '))
 			return query.exec()

--- a/lib/request.coffee
+++ b/lib/request.coffee
@@ -178,7 +178,7 @@ module.exports = class Request
 					deferred.resolve(query)
 				else
 					
-					@$modelClass.countQ(filter)
+					@$modelClass.count(filter)
 					.then (count) =>
 						res.set('Time-PostCount', (new Date()).toISOString())
 						log 'There are ' + count.toString().yellow + ' total documents that fit filter'
@@ -234,7 +234,7 @@ module.exports = class Request
 
 		@$runHook('pre_save', 'post', req, model).then (model) =>
 
-			return model.saveQ()
+			return model.save()
 		.then (model) =>
 			log('Finished save. Populating')
 			return @$populateDocument(model)
@@ -258,7 +258,7 @@ module.exports = class Request
 		deferred = Q.defer()
 		model = new @$modelClass(obj)
 		@$runHook('pre_save', 'bulkpost', req, model).then (data) =>
-			return model.saveQ()
+			return model.save()
 		.then (model) =>
 			deferred.resolve()
 		.fail (err) =>
@@ -358,7 +358,7 @@ module.exports = class Request
 				model.set(req.body)
 				return @$runHook('pre_save', 'put', req, model).then (model) =>
 			.then =>
-				return model.saveQ()
+				return model.save()
 			.then (model) =>
 				return @$populateDocument(model)
 			.then (model) =>
@@ -425,7 +425,7 @@ module.exports = class Request
 					res.status(500).send()
 				.done()
 			@$runHook('post_retrieve', 'delete', req, model).then (model) =>
-				return model.removeQ()
+				return model.remove()
 			.then =>
 				res.status(200).send()
 			.fail (err) =>

--- a/package.json
+++ b/package.json
@@ -19,12 +19,12 @@
     "coffee-script": "^1.8.0",
     "colors": "^0.6.2",
     "dot-component": "~0.1.0",
-    "express": "3.4.3",
+    "express": "^4.15.2",
     "hooks": "~0.3.2",
     "minimatch": "^1.0.0",
     "moment": "~2.6.0",
     "mongoose": "^4.9.1",
-    "q": "*",
+    "q": "^1.5.0",
     "underscore": "~1.5.2"
   },
   "author": {
@@ -46,6 +46,5 @@
     "grunt-exec": "~0.4.3",
     "grunt-sed": "~0.1.1",
     "semver": "~2.2.1",
-    "moment": "~2.5.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "hooks": "~0.3.2",
     "minimatch": "^1.0.0",
     "moment": "~2.6.0",
-    "mongoose-q": "0.0.13",
+    "mongoose": "^4.9.1",
     "q": "*",
     "underscore": "~1.5.2"
   },

--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-exec": "~0.4.3",
     "grunt-sed": "~0.1.1",
-    "semver": "~2.2.1",
+    "semver": "~2.2.1"
   }
 }


### PR DESCRIPTION
mongoose-q was used in order to get Promise-based workflow in mongoose, mongoose supports promises for some time now, so I've removed mongoose-q as a dependency, updated mongoose, and fixed API usage so any `model.saveQ(` became `model.save(` etc

additionally I have:
- set mongoose to use kriskowal's Q Promises
- upgraded express package to the newest, as old one was having several vulnerabilities detected by snyk.io
- fixed 'q' package version in package.json
- fixed pagination parameter usage as it was causing problems in new version of mongoose