### PR TITLE
KR-1886: Dockerize mongoose-rest-endpoints and gets tests running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
   - docker-compose build
 
 script:
-  - docker-compose up
+  - docker-compose run mongoose-rest-endpoints-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,27 @@
-language: node_js
-node_js:
-  - "0.10"
-before_install: npm config set strict-ssl false && npm install -g grunt-cli mocha
-services: mongodb
+sudo: false
+dist: trusty
+group: edge
+
+services:
+- docker
+
+env:
+  global:
+  - TEAM_NAME: krypton
+  - QA_BRANCH: master
+  - PROJECT_NAME: mongoose-rest-endpoints
+  - AWS_DEFAULT_REGION: us-east-1
+
+before_install:
+  - openssl aes-256-cbc -K $encrypted_7dabc08677cf_key -iv $encrypted_7dabc08677cf_iv -in private.key.enc -out private.key -d
+
+script:
+  - mkdir coverage .nyc_output
+  - pip install --upgrade setuptools --user python
+  - pip install --user awscli
+  - eval "$(aws ecr get-login --no-include-email)"
+  - eval $(docker run --name bootstrap 165918379116.dkr.ecr.us-east-1.amazonaws.com/travis:latest_eks /_bootstrap/bootstrap.sh)
+
+branches:
+  only:
+  - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,20 @@
 sudo: false
 dist: trusty
-group: edge
-
-services:
-- docker
-
-env:
-  global:
-  - TEAM_NAME: krypton
-  - QA_BRANCH: master
-  - PROJECT_NAME: mongoose-rest-endpoints
-  - AWS_DEFAULT_REGION: us-east-1
-
-before_install:
-  - openssl aes-256-cbc -K $encrypted_7dabc08677cf_key -iv $encrypted_7dabc08677cf_iv -in private.key.enc -out private.key -d
-
-script:
-  - mkdir coverage .nyc_output
-  - pip install --upgrade setuptools --user python
-  - pip install --user awscli
-  - eval "$(aws ecr get-login --no-include-email)"
-  - eval $(docker run --name bootstrap 165918379116.dkr.ecr.us-east-1.amazonaws.com/travis:latest_eks /_bootstrap/bootstrap.sh)
 
 branches:
   only:
-  - master
+    - master
+
+services:
+  - docker
+
+env:
+  global:
+    - TEAM_NAME: krypton
+    - AWS_DEFAULT_REGION: 'us-east-1'
+
+install:
+  - docker-compose build
+
+script:
+  - docker-compose up

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node:6-alpine
+
+MAINTAINER Krypton "krypton@maxwellhealth.com"
+
+RUN apk add --no-cache \
+    attr \
+    bash \
+    ca-certificates \
+    make \
+    unzip
+
+RUN mkdir -p /var/www/edi/
+WORKDIR /var/www/edi/
+COPY . .
+
+RUN npm install -g grunt-cli
+RUN npm install -g mocha@^5.2.0
+RUN npm install
+RUN npm install body-parser
+RUN npm install method-override
+
+CMD npm run test

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,9 @@ WORKDIR /var/www/edi/
 COPY . .
 
 RUN npm install -g grunt-cli
-RUN npm install -g mocha@^5.2.0
 RUN npm install
-RUN npm install body-parser
-RUN npm install method-override
+RUN npm install mocha --save-dev
+RUN npm install body-parser --save-dev
+RUN npm install method-override --save-dev
 
 CMD ./wait-for-it.sh mongo:27017 -- npm run test

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ RUN npm install
 RUN npm install body-parser
 RUN npm install method-override
 
-CMD npm run test
+CMD ./wait-for-it.sh mongo:27017 -- npm run test

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,5 @@ COPY . .
 
 RUN npm install -g grunt-cli
 RUN npm install
-RUN npm install mocha --save-dev
-RUN npm install body-parser --save-dev
-RUN npm install method-override --save-dev
 
 CMD ./wait-for-it.sh mongo:27017 -- npm run test

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,7 +20,7 @@ module.exports = function(grunt) {
 		exec:{
 			test: {
 				cmd:function(ex) {
-					return f('NODE_ENV=test mocha --require coffee-script/register %s', ex)
+					return f('NODE_ENV=test mocha --exit --require coffee-script/register %s', ex)
 				}
 			}
 		}
@@ -47,7 +47,7 @@ module.exports = function(grunt) {
 	});
 
 	grunt.registerTask('test', 'Run tests', function(type) {
-		var tasks = ['dropTestDb']
+		var tasks = ['dropTestDb'];
 		if(type === undefined) {
 			type = 'all';
 		}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,7 +8,6 @@ var fs = require('fs');
 module.exports = function(grunt) {
 	grunt.loadNpmTasks('grunt-contrib-watch');
 	grunt.loadNpmTasks('grunt-exec');
-	grunt.loadNpmTasks('grunt-sed');
 	grunt.loadNpmTasks('grunt-contrib-coffee');
 	grunt.initConfig({
 		version: grunt.file.readJSON('package.json').version,
@@ -21,7 +20,7 @@ module.exports = function(grunt) {
 		exec:{
 			test: {
 				cmd:function(ex) {
-					return f('NODE_ENV=test mocha --compilers coffee:coffee-script/register %s', ex)
+					return f('NODE_ENV=test mocha --require coffee-script/register %s', ex)
 				}
 			}
 		}
@@ -59,16 +58,17 @@ module.exports = function(grunt) {
 				var file;
 				for(var i=0;i<files.length;i++) {
 					file = files[i];
-						tasks.push('exec:test:"test/' + file + '"')
+					tasks.push('exec:test:"test/' + file + '"')
 				}
-
-				console.log(tasks);
 				//tasks = ['exec:test:"test/unit/*.js"']
 				break;
 			default:
 				tasks = ['dropTestDb', 'exec:test:"test/' + type + '.coffee"', 'dropTestDb']
 				break;
 		}
+
+		console.log(tasks);
+
 		grunt.task.run(tasks);
 	});
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,7 +20,7 @@ module.exports = function(grunt) {
 		exec:{
 			test: {
 				cmd:function(ex) {
-					return f('NODE_ENV=test mocha --exit --require coffee-script/register %s', ex)
+					return f('NODE_ENV=test mocha --compilers coffee:coffee-script/register %s', ex)
 				}
 			}
 		}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,7 +30,11 @@ module.exports = function(grunt) {
 	grunt.registerTask('dropTestDb', function() {
 		var mongoose = require('mongoose');
 		var done = this.async();
-		mongoose.connect('mongodb://localhost/mre_test')
+		var mongoUrlCreds = process.env.MONGO_USERNAME 
+			? (process.env.MONGO_USERNAME+":"+process.env.MONGO_PASSWORD+"@") 
+			: "";
+		var mongoUrl = "mongodb://" + mongoUrlCreds + process.env.MONGO_HOST;
+		mongoose.connect(mongoUrl+"/mre_test")
 		mongoose.connection.on('open', function () { 
 			mongoose.connection.db.dropDatabase(function(err) {
 				if(err) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,10 @@ services:
   mongo:
     image: mongo:3.4.16
     restart: always
-    expose:
-      - "27017"
+    command: --smallfiles
     ports:
       - "27017:27017"
-      
+
   mongoose-rest-endpoints-test:
     build: .
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.2'
+
+services:
+
+  mongo:
+    image: mongo:3.4.16
+    restart: always
+    expose:
+      - "27017"
+    ports:
+      - "27017:27017"
+      
+  mongoose-rest-endpoints-test:
+    build: .
+    depends_on:
+      - mongo
+    links:
+      - mongo
+    environment:
+      NODE_ENV: "test"
+      MONGO_HOST: mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       - mongo
     links:
       - mongo
+    volumes:
+      - ./test:/var/www/edi/test
     environment:
       NODE_ENV: "test"
       MONGO_HOST: mongo

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,7 @@ version: '3.2'
 services:
 
   mongo:
-    image: mongo:3.4.16
-    # image: mongo:3.6
+    image: mongo:3.6
     restart: always
     command: --smallfiles
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,11 @@ services:
 
   mongo:
     image: mongo:3.4.16
+    # image: mongo:3.6
     restart: always
     command: --smallfiles
+    expose:
+      - "27017"
     ports:
       - "27017:27017"
 

--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
     "API"
   ],
   "dependencies": {
-    "coffee-script": "^1.8.0",
-    "colors": "^0.6.2",
+    "coffee-script": "~1.8.0",
+    "colors": "~0.6.2",
     "dot-component": "~0.1.0",
-    "express": "^4.15.2",
+    "express": "~4.15.2",
     "hooks": "~0.3.2",
-    "minimatch": "^1.0.0",
+    "minimatch": "~1.0.0",
     "moment": "~2.6.0",
-    "mongoose": "^4.9.1",
-    "q": "^1.5.0",
+    "mongoose": "~4.9.1",
+    "q": "~1.5.0",
     "underscore": "~1.5.2"
   },
   "author": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "grunt-contrib-coffee": "~0.8.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-exec": "~0.4.3",
-    "grunt-sed": "~0.1.1",
     "semver": "~2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "hooks": "~0.3.2",
     "minimatch": "~1.0.0",
     "moment": "~2.6.0",
-    "mongoose": "~4.9.1",
+    "mongoose": "~5.6.9",
     "q": "~1.5.0",
     "underscore": "~1.5.2"
   },

--- a/package.json
+++ b/package.json
@@ -38,12 +38,15 @@
   "homepage": "https://github.com/jraede/mongoose-rest-endpoints",
   "readme": "README.md",
   "devDependencies": {
-    "supertest": "~0.8.2",
-    "should": "~2.1.1",
+    "body-parser": "^1.19.0",
     "grunt": "~0.4.2",
     "grunt-contrib-coffee": "~0.8.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-exec": "~0.4.3",
-    "semver": "~2.2.1"
+    "method-override": "^3.0.0",
+    "mocha": "^2.5.3",
+    "semver": "~2.2.1",
+    "should": "~2.1.1",
+    "supertest": "~0.8.2"
   }
 }

--- a/test/bulkpost.coffee
+++ b/test/bulkpost.coffee
@@ -118,8 +118,8 @@ describe 'Bulk Post', ->
 				res.body[0].state.should.equal('fulfilled')
 				res.body[1].state.should.equal('rejected')
 				res.body[2].state.should.equal('rejected')
-				res.body[1].reason.message.message.should.equal('Post validation failed')
-				res.body[2].reason.message.message.should.equal('Post validation failed')
+				res.body[1].reason.message.message.should.equal('Post validation failed: string: Path `string` is required.')
+				res.body[2].reason.message.message.should.equal('Post validation failed: string: Path `string` is required.')
 				done()
 
 		it 'should have the first error code if they are all errors', (done) ->

--- a/test/bulkpost.coffee
+++ b/test/bulkpost.coffee
@@ -45,32 +45,38 @@ requirePassword = (password) ->
 			next()
 		else
 			res.send(401)
-mongoUrlCreds = if process.env.MONGO_USERNAME then "#{process.env.MONGO_USERNAME}:#{process.env.MONGO_PASSWORD}@" else ""
-mongoose.connect("mongodb://#{mongoUrlCreds}#{process.env.MONGO_HOST}/mre_test")
-
-
-
-mongoose.model('Post', postSchema)
-mongoose.model('Comment', commentSchema)
-mongoose.model('Author', authorSchema)
-
-mongoose.set 'debug', true
-
-
 
 describe 'Bulk Post', ->
-	@timeout(5000)
+	before ->
+		mongoUrlCreds = if process.env.MONGO_USERNAME then "#{process.env.MONGO_USERNAME}:#{process.env.MONGO_PASSWORD}@" else ""
+		mongoose.connect("mongodb://#{mongoUrlCreds}#{process.env.MONGO_HOST}/mre_test", { useMongoClient: true })
+		mongoose.model('Post', postSchema)
+		mongoose.model('Comment', commentSchema)
+		mongoose.model('Author', authorSchema)
+		mongoose.set 'debug', true
+
+	after (done) ->
+		mongoose.connection.db.dropDatabase (err) ->
+			if err
+				console.log err
+			else
+				console.log 'Successfully dropped db'
+			mongoose.connection.close()
+			done()
+
+	@timeout(10000)
 	describe 'Basic object', ->
-		beforeEach (done) ->
+		beforeEach ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(bodyParser())
+			@app.use(bodyParser.urlencoded({extended: true}))
+			@app.use(bodyParser.json())
 			@app.use(methodOverride())
-			done()
+
 		afterEach (done) ->
-			# clear out
-			mongoose.connection.collections.posts.drop()
-			done()
+			mongoose.connection.collections.posts.drop (err, result) ->
+				done()
+			
 		it 'should let you bulk post with no hooks', (done) ->
 
 			@endpoint.allowBulkPost().register(@app)
@@ -84,7 +90,6 @@ describe 'Bulk Post', ->
 					number:8
 					string:'Foo'
 			]
-				
 
 			request(@app).post('/api/posts/bulk').send(data).end (err, res) ->
 				res.status.should.equal(201)
@@ -136,5 +141,3 @@ describe 'Bulk Post', ->
 				
 				res.status.should.equal(400)
 				done()
-
-		

--- a/test/bulkpost.coffee
+++ b/test/bulkpost.coffee
@@ -1,4 +1,6 @@
 express = require 'express'
+bodyParser = require 'body-parser'
+methodOverride = require 'method-override'
 request = require 'supertest'
 should = require 'should'
 Q = require 'q'
@@ -43,7 +45,8 @@ requirePassword = (password) ->
 			next()
 		else
 			res.send(401)
-mongoose.connect('mongodb://localhost/mre_test')
+mongoUrlCreds = if process.env.MONGO_USERNAME then "#{process.env.MONGO_USERNAME}:#{process.env.MONGO_PASSWORD}@" else ""
+mongoose.connect("mongodb://#{mongoUrlCreds}#{process.env.MONGO_HOST}/mre_test")
 
 
 
@@ -61,8 +64,8 @@ describe 'Bulk Post', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(express.bodyParser())
-			@app.use(express.methodOverride())
+			@app.use(bodyParser())
+			@app.use(methodOverride())
 			done()
 		afterEach (done) ->
 			# clear out
@@ -110,8 +113,8 @@ describe 'Bulk Post', ->
 				res.body[0].state.should.equal('fulfilled')
 				res.body[1].state.should.equal('rejected')
 				res.body[2].state.should.equal('rejected')
-				res.body[1].reason.message.message.should.equal('Validation failed')
-				res.body[2].reason.message.message.should.equal('Validation failed')
+				res.body[1].reason.message.message.should.equal('Post validation failed: string: Path `string` is required.')
+				res.body[2].reason.message.message.should.equal('Post validation failed: string: Path `string` is required.')
 				done()
 
 		it 'should have the first error code if they are all errors', (done) ->

--- a/test/bulkpost.coffee
+++ b/test/bulkpost.coffee
@@ -118,8 +118,8 @@ describe 'Bulk Post', ->
 				res.body[0].state.should.equal('fulfilled')
 				res.body[1].state.should.equal('rejected')
 				res.body[2].state.should.equal('rejected')
-				res.body[1].reason.message.message.should.equal('Post validation failed: string: Path `string` is required.')
-				res.body[2].reason.message.message.should.equal('Post validation failed: string: Path `string` is required.')
+				res.body[1].reason.message.message.should.equal('Post validation failed')
+				res.body[2].reason.message.message.should.equal('Post validation failed')
 				done()
 
 		it 'should have the first error code if they are all errors', (done) ->

--- a/test/delete.coffee
+++ b/test/delete.coffee
@@ -1,4 +1,6 @@
 express = require 'express'
+bodyParser = require 'body-parser'
+methodOverride = require 'method-override'
 request = require 'supertest'
 should = require 'should'
 Q = require 'q'
@@ -40,7 +42,8 @@ requirePassword = (password) ->
 			next()
 		else
 			res.send(401)
-mongoose.connect('mongodb://localhost/mre_test')
+mongoUrlCreds = if process.env.MONGO_USERNAME then "#{process.env.MONGO_USERNAME}:#{process.env.MONGO_PASSWORD}@" else ""
+mongoose.connect("mongodb://#{mongoUrlCreds}#{process.env.MONGO_HOST}/mre_test")
 
 
 
@@ -58,8 +61,8 @@ describe 'Delete', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(express.bodyParser())
-			@app.use(express.methodOverride())
+			@app.use(bodyParser())
+			@app.use(methodOverride())
 			modClass = mongoose.model('Post')
 			mod = modClass
 				date:Date.now()

--- a/test/delete.coffee
+++ b/test/delete.coffee
@@ -43,7 +43,7 @@ requirePassword = (password) ->
 		else
 			res.send(401)
 mongoUrlCreds = if process.env.MONGO_USERNAME then "#{process.env.MONGO_USERNAME}:#{process.env.MONGO_PASSWORD}@" else ""
-mongoose.connect("mongodb://#{mongoUrlCreds}#{process.env.MONGO_HOST}/mre_test")
+mongoose.connect("mongodb://#{mongoUrlCreds}#{process.env.MONGO_HOST}/mre_test", { useMongoClient: true })
 
 
 
@@ -61,7 +61,8 @@ describe 'Delete', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(bodyParser())
+			@app.use(bodyParser.urlencoded({extended: true}))
+			@app.use(bodyParser.json())
 			@app.use(methodOverride())
 			modClass = mongoose.model('Post')
 			mod = modClass

--- a/test/fetch.coffee
+++ b/test/fetch.coffee
@@ -66,7 +66,8 @@ describe 'Fetch', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(bodyParser())
+			@app.use(bodyParser.urlencoded({extended: true}))
+			@app.use(bodyParser.json())
 			@app.use(methodOverride())
 
 			modClass = mongoose.model('Post')
@@ -141,7 +142,8 @@ describe 'Fetch', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(bodyParser())
+			@app.use(bodyParser.urlencoded({extended: true}))
+			@app.use(bodyParser.json())
 			@app.use(methodOverride())
 
 			modClass = mongoose.model('Post')
@@ -185,7 +187,8 @@ describe 'Fetch', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(bodyParser())
+			@app.use(bodyParser.urlencoded({extended: true}))
+			@app.use(bodyParser.json())
 			@app.use(methodOverride())
 
 			modClass = mongoose.model('Post')

--- a/test/fetch.coffee
+++ b/test/fetch.coffee
@@ -1,4 +1,6 @@
 express = require 'express'
+bodyParser = require 'body-parser'
+methodOverride = require 'method-override'
 request = require 'supertest'
 should = require 'should'
 Q = require 'q'
@@ -45,7 +47,8 @@ requirePassword = (password) ->
 			next()
 		else
 			res.send(401)
-mongoose.connect('mongodb://localhost/mre_test')
+mongoUrlCreds = if process.env.MONGO_USERNAME then "#{process.env.MONGO_USERNAME}:#{process.env.MONGO_PASSWORD}@" else ""
+mongoose.connect("mongodb://#{mongoUrlCreds}#{process.env.MONGO_HOST}/mre_test")
 
 
 
@@ -63,8 +66,8 @@ describe 'Fetch', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(express.bodyParser())
-			@app.use(express.methodOverride())
+			@app.use(bodyParser())
+			@app.use(methodOverride())
 
 			modClass = mongoose.model('Post')
 			mod = modClass
@@ -138,8 +141,8 @@ describe 'Fetch', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(express.bodyParser())
-			@app.use(express.methodOverride())
+			@app.use(bodyParser())
+			@app.use(methodOverride())
 
 			modClass = mongoose.model('Post')
 			mod = modClass
@@ -182,8 +185,8 @@ describe 'Fetch', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(express.bodyParser())
-			@app.use(express.methodOverride())
+			@app.use(bodyParser())
+			@app.use(methodOverride())
 
 			modClass = mongoose.model('Post')
 			mod = modClass

--- a/test/fetch.coffee
+++ b/test/fetch.coffee
@@ -203,7 +203,7 @@ describe 'Fetch', ->
 
 			mod._comments = [comment._id]
 			@mod = mod
-			Q.all([mod.saveQ(), comment.saveQ()]).then ->
+			Q.all([mod.save(), comment.save()]).then ->
 				done()
 			.fail(done).done()
 		afterEach (done) -> 

--- a/test/list.coffee
+++ b/test/list.coffee
@@ -1,4 +1,6 @@
 express = require 'express'
+bodyParser = require 'body-parser'
+methodOverride = require 'method-override'
 request = require 'supertest'
 should = require 'should'
 Q = require 'q'
@@ -56,7 +58,8 @@ createPost = (data) ->
 		return deferred.resolve()
 
 	return deferred.promise
-mongoose.connect('mongodb://localhost/mre_test')
+mongoUrlCreds = if process.env.MONGO_USERNAME then "#{process.env.MONGO_USERNAME}:#{process.env.MONGO_PASSWORD}@" else ""
+mongoose.connect("mongodb://#{mongoUrlCreds}#{process.env.MONGO_HOST}/mre_test")
 
 
 mongoose.model('Post', postSchema)
@@ -73,8 +76,8 @@ describe 'List', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(express.bodyParser())
-			@app.use(express.methodOverride())
+			@app.use(bodyParser())
+			@app.use(methodOverride())
 
 			modClass = mongoose.model('Post')
 			mod = modClass
@@ -223,8 +226,8 @@ describe 'List', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(express.bodyParser())
-			@app.use(express.methodOverride())
+			@app.use(bodyParser())
+			@app.use(methodOverride())
 
 			modClass = mongoose.model('Post')
 			mod = modClass
@@ -262,8 +265,8 @@ describe 'List', ->
 			
 			# set up endpoints
 			@app = express()
-			@app.use(express.bodyParser())
-			@app.use(express.methodOverride())
+			@app.use(bodyParser())
+			@app.use(methodOverride())
 			# Create a whole bunch of posts
 			data = [
 					date:moment().add('days', 26).toDate()
@@ -332,8 +335,8 @@ describe 'List', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(express.bodyParser())
-			@app.use(express.methodOverride())
+			@app.use(bodyParser())
+			@app.use(methodOverride())
 
 			modClass = mongoose.model('Post')
 			mod = modClass
@@ -364,8 +367,8 @@ describe 'List', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(express.bodyParser())
-			@app.use(express.methodOverride())
+			@app.use(bodyParser())
+			@app.use(methodOverride())
 
 			modClass = mongoose.model('Post')
 			mod = modClass

--- a/test/list.coffee
+++ b/test/list.coffee
@@ -243,7 +243,7 @@ describe 'List', ->
 
 			mod._comments = [comment._id]
 			@mod = mod
-			Q.all([mod.saveQ(), comment.saveQ()]).then ->
+			Q.all([mod.save(), comment.save()]).then ->
 				done()
 			.fail(done).done()
 

--- a/test/list.coffee
+++ b/test/list.coffee
@@ -76,7 +76,8 @@ describe 'List', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(bodyParser())
+			@app.use(bodyParser.urlencoded({extended: true}))
+			@app.use(bodyParser.json())
 			@app.use(methodOverride())
 
 			modClass = mongoose.model('Post')
@@ -226,7 +227,8 @@ describe 'List', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(bodyParser())
+			@app.use(bodyParser.urlencoded({extended: true}))
+			@app.use(bodyParser.json())
 			@app.use(methodOverride())
 
 			modClass = mongoose.model('Post')
@@ -265,7 +267,8 @@ describe 'List', ->
 			
 			# set up endpoints
 			@app = express()
-			@app.use(bodyParser())
+			@app.use(bodyParser.urlencoded({extended: true}))
+			@app.use(bodyParser.json())
 			@app.use(methodOverride())
 			# Create a whole bunch of posts
 			data = [
@@ -335,7 +338,8 @@ describe 'List', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(bodyParser())
+			@app.use(bodyParser.urlencoded({extended: true}))
+			@app.use(bodyParser.json())
 			@app.use(methodOverride())
 
 			modClass = mongoose.model('Post')
@@ -367,7 +371,8 @@ describe 'List', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(bodyParser())
+			@app.use(bodyParser.urlencoded({extended: true}))
+			@app.use(bodyParser.json())
 			@app.use(methodOverride())
 
 			modClass = mongoose.model('Post')

--- a/test/post.coffee
+++ b/test/post.coffee
@@ -64,7 +64,8 @@ describe 'Post', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', mongoose.model('Post'))
 			@app = express()
-			@app.use(bodyParser())
+			@app.use(bodyParser.urlencoded({extended: true}))
+			@app.use(bodyParser.json())
 			@app.use(methodOverride())
 			done()
 		afterEach (done) ->

--- a/test/post.coffee
+++ b/test/post.coffee
@@ -1,4 +1,6 @@
 express = require 'express'
+bodyParser = require 'body-parser'
+methodOverride = require 'method-override'
 request = require 'supertest'
 should = require 'should'
 Q = require 'q'
@@ -43,7 +45,8 @@ requirePassword = (password) ->
 			next()
 		else
 			res.send(401)
-mongoose.connect('mongodb://localhost/mre_test')
+mongoUrlCreds = if process.env.MONGO_USERNAME then "#{process.env.MONGO_USERNAME}:#{process.env.MONGO_PASSWORD}@" else ""
+mongoose.connect("mongodb://#{mongoUrlCreds}#{process.env.MONGO_HOST}/mre_test")
 
 
 
@@ -61,8 +64,8 @@ describe 'Post', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', mongoose.model('Post'))
 			@app = express()
-			@app.use(express.bodyParser())
-			@app.use(express.methodOverride())
+			@app.use(bodyParser())
+			@app.use(methodOverride())
 			done()
 		afterEach (done) ->
 			# clear out

--- a/test/put.coffee
+++ b/test/put.coffee
@@ -61,7 +61,8 @@ describe 'Put', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(bodyParser())
+			@app.use(bodyParser.urlencoded({extended: true}))
+			@app.use(bodyParser.json())
 			@app.use(methodOverride())
 			modClass = mongoose.model('Post')
 			mod = modClass

--- a/test/put.coffee
+++ b/test/put.coffee
@@ -1,4 +1,6 @@
 express = require 'express'
+bodyParser = require 'body-parser'
+methodOverride = require 'method-override'
 request = require 'supertest'
 should = require 'should'
 Q = require 'q'
@@ -40,7 +42,8 @@ requirePassword = (password) ->
 			next()
 		else
 			res.send(401)
-mongoose.connect('mongodb://localhost/mre_test')
+mongoUrlCreds = if process.env.MONGO_USERNAME then "#{process.env.MONGO_USERNAME}:#{process.env.MONGO_PASSWORD}@" else ""
+mongoose.connect("mongodb://#{mongoUrlCreds}#{process.env.MONGO_HOST}/mre_test")
 
 
 
@@ -58,8 +61,8 @@ describe 'Put', ->
 		beforeEach (done) ->
 			@endpoint = new mre('/api/posts', 'Post')
 			@app = express()
-			@app.use(express.bodyParser())
-			@app.use(express.methodOverride())
+			@app.use(bodyParser())
+			@app.use(methodOverride())
 			modClass = mongoose.model('Post')
 			mod = modClass
 				date:Date.now()

--- a/wait-for-it.sh
+++ b/wait-for-it.sh
@@ -1,0 +1,178 @@
+#!/bin/bash
+#   Use this script to test if a given TCP host/port are available
+
+WAITFORIT_cmdname=${0##*/}
+
+echoerr() { if [[ $WAITFORIT_QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $WAITFORIT_cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    else
+        echoerr "$WAITFORIT_cmdname: waiting for $WAITFORIT_HOST:$WAITFORIT_PORT without a timeout"
+    fi
+    WAITFORIT_start_ts=$(date +%s)
+    while :
+    do
+        if [[ $WAITFORIT_ISBUSY -eq 1 ]]; then
+            nc -z $WAITFORIT_HOST $WAITFORIT_PORT
+            WAITFORIT_result=$?
+        else
+            (echo > /dev/tcp/$WAITFORIT_HOST/$WAITFORIT_PORT) >/dev/null 2>&1
+            WAITFORIT_result=$?
+        fi
+        if [[ $WAITFORIT_result -eq 0 ]]; then
+            WAITFORIT_end_ts=$(date +%s)
+            echoerr "$WAITFORIT_cmdname: $WAITFORIT_HOST:$WAITFORIT_PORT is available after $((WAITFORIT_end_ts - WAITFORIT_start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $WAITFORIT_result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $WAITFORIT_QUIET -eq 1 ]]; then
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --quiet --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    else
+        timeout $WAITFORIT_BUSYTIMEFLAG $WAITFORIT_TIMEOUT $0 --child --host=$WAITFORIT_HOST --port=$WAITFORIT_PORT --timeout=$WAITFORIT_TIMEOUT &
+    fi
+    WAITFORIT_PID=$!
+    trap "kill -INT -$WAITFORIT_PID" INT
+    wait $WAITFORIT_PID
+    WAITFORIT_RESULT=$?
+    if [[ $WAITFORIT_RESULT -ne 0 ]]; then
+        echoerr "$WAITFORIT_cmdname: timeout occurred after waiting $WAITFORIT_TIMEOUT seconds for $WAITFORIT_HOST:$WAITFORIT_PORT"
+    fi
+    return $WAITFORIT_RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        WAITFORIT_hostport=(${1//:/ })
+        WAITFORIT_HOST=${WAITFORIT_hostport[0]}
+        WAITFORIT_PORT=${WAITFORIT_hostport[1]}
+        shift 1
+        ;;
+        --child)
+        WAITFORIT_CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        WAITFORIT_QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        WAITFORIT_STRICT=1
+        shift 1
+        ;;
+        -h)
+        WAITFORIT_HOST="$2"
+        if [[ $WAITFORIT_HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        WAITFORIT_HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        WAITFORIT_PORT="$2"
+        if [[ $WAITFORIT_PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        WAITFORIT_PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        WAITFORIT_TIMEOUT="$2"
+        if [[ $WAITFORIT_TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        WAITFORIT_TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        WAITFORIT_CLI=("$@")
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$WAITFORIT_HOST" == "" || "$WAITFORIT_PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+WAITFORIT_TIMEOUT=${WAITFORIT_TIMEOUT:-15}
+WAITFORIT_STRICT=${WAITFORIT_STRICT:-0}
+WAITFORIT_CHILD=${WAITFORIT_CHILD:-0}
+WAITFORIT_QUIET=${WAITFORIT_QUIET:-0}
+
+# check to see if timeout is from busybox?
+WAITFORIT_TIMEOUT_PATH=$(type -p timeout)
+WAITFORIT_TIMEOUT_PATH=$(realpath $WAITFORIT_TIMEOUT_PATH 2>/dev/null || readlink -f $WAITFORIT_TIMEOUT_PATH)
+if [[ $WAITFORIT_TIMEOUT_PATH =~ "busybox" ]]; then
+        WAITFORIT_ISBUSY=1
+        WAITFORIT_BUSYTIMEFLAG="-t"
+
+else
+        WAITFORIT_ISBUSY=0
+        WAITFORIT_BUSYTIMEFLAG=""
+fi
+
+if [[ $WAITFORIT_CHILD -gt 0 ]]; then
+    wait_for
+    WAITFORIT_RESULT=$?
+    exit $WAITFORIT_RESULT
+else
+    if [[ $WAITFORIT_TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        WAITFORIT_RESULT=$?
+    else
+        wait_for
+        WAITFORIT_RESULT=$?
+    fi
+fi
+
+if [[ $WAITFORIT_CLI != "" ]]; then
+    if [[ $WAITFORIT_RESULT -ne 0 && $WAITFORIT_STRICT -eq 1 ]]; then
+        echoerr "$WAITFORIT_cmdname: strict mode, refusing to execute subprocess"
+        exit $WAITFORIT_RESULT
+    fi
+    exec "${WAITFORIT_CLI[@]}"
+else
+    exit $WAITFORIT_RESULT
+fi


### PR DESCRIPTION
We're upgrading to mongo 3.6 soon, so we need to have the unit tests running as a preliminary check to make sure the upgrade doesn't break anything.

(maxwell-edi depends on this little package, so we have to keep it limping along)